### PR TITLE
Add minecraft-addon-toolchain-jsonvalidator as a default plugin for g…

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -8,6 +8,7 @@ const toolchainVersion = "^1.0.3";
 const toolchainTypeScriptVersion = "^1.0.3";
 const toolchainBrowserifyVersion = "^1.0.3";
 const typescriptTypesVersion = "^1.0.0";
+const toolchainJsonValidateVersion = "^1.0.0";
 
 module.exports = class extends Generator {
 	async prompting() {
@@ -86,7 +87,8 @@ module.exports = class extends Generator {
 				packageaddon: "gulp package"
 			},
 			devDependencies: {
-				"minecraft-addon-toolchain": toolchainVersion
+				"minecraft-addon-toolchain": toolchainVersion,
+				"minecraft-addon-toolchain-jsonvalidator": toolchainJsonValidateVersion
 			}
 		};
 

--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -1,4 +1,5 @@
 const MinecraftAddonBuilder = require("minecraft-addon-toolchain/v1");
+const JSONValidator = require("minecraft-addon-toolchain-jsonvalidator");
 <%_ if (useTypescript) { -%>
 const TypeScriptSupport = require("minecraft-addon-toolchain-typescript");
 <%_ } -%>
@@ -7,6 +8,7 @@ const BrowserifySupport = require("minecraft-addon-toolchain-browserify");
 <%_ } -%>
 
 const builder = new MinecraftAddonBuilder("<%= addonName %>");
+builder.addPlugin(new JSONValidator());
 <%_ if (useTypescript) { -%>
 builder.addPlugin(new TypeScriptSupport());
 <%_ } -%>


### PR DESCRIPTION
This adds the minecraft-addon-toolchain-jsonvalidator plugin as a default plugin to generated add-ons.

This plugin:
* Runs jsonlint on all .json files during the build process
* Displays error messages describing the location and type of error for malformed json files
* Halts build after processing all json files if there are any errors