### PR TITLE
Add validation to require user to select at least one module.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -35,7 +35,11 @@ module.exports = class extends Generator {
 				type: "checkbox",
 				name: "addonModules",
 				message: "What kind of modules will make up the addon?",
-				choices: ["Behaviors", "Resources"]
+				choices: ["Behaviors", "Resources"],
+				validate: userInput => {
+					// Require a choice
+					return userInput.length === 0 ? "Please choose at least one module" : true;
+				}
 			},
 			{
 				type: "confirm",


### PR DESCRIPTION
This adds a validate function that requires the user to choose at least one module (Behaviors or Resources) before proceeding. This should prevent confusion like in Issue #9 